### PR TITLE
Implement the User-SupportEmail Relationship

### DIFF
--- a/src/foam/support/modal/NewEmailSupportModal.js
+++ b/src/foam/support/modal/NewEmailSupportModal.js
@@ -138,19 +138,31 @@ foam.CLASS({
         name: 'nextButton',
         label: 'Next',
         code: function(X){
-          if(!this.email) return;
-          var emailRegex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-          if (!emailRegex.test(this.email)){
-            this.add(this.NotificationMessage.create({ message: 'The email you have entered is invalid, try again.', type: 'error' })); 
-            return;
-          }
-          var email = this.SupportEmail.create({
-            email: this.email,
-            userId: this.user.id
-          })
-          this.supportEmailDAO.put(email);
-          this.ctrl.add(foam.u2.dialog.Popup.create().tag({ class: 'foam.support.modal.NewEmailSupportConfirmationModal'}));
-          X.closeDialog()
+        var expr = foam.mlang.Expressions.create();
+
+        if(!this.email) return;
+        var self = this;
+        // check to see if the user email is existed
+        this.supportEmailDAO.where(expr.EQ(this.SupportEmail.EMAIL, this.email)).select().then(
+          function(result){
+            if (result.a.length == 0) {
+              const emailRegex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+              console.log(self.email);
+              if (!emailRegex.test(self.email)){
+                self.add(self.NotificationMessage.create({ message: 'The email you have entered is invalid, try again.', type: 'error' })); 
+                return;
+              }
+              var email = self.SupportEmail.create({
+                email: self.email,
+                userId: self.user.id,
+              });
+              self.supportEmailDAO.put(email);
+              self.ctrl.add(foam.u2.dialog.Popup.create().tag({ class: 'foam.support.modal.NewEmailSupportConfirmationModal'}));
+              X.closeDialog()
+            } else {
+              self.add(self.NotificationMessage.create({ message: 'The email you have entered is existed.', type: 'error' })); 
+            }
+        });
         }
       },
       {

--- a/src/foam/support/modal/NewEmailSupportModal.js
+++ b/src/foam/support/modal/NewEmailSupportModal.js
@@ -155,10 +155,10 @@ foam.CLASS({
               var email = self.SupportEmail.create({
                 email: self.email,
                 userId: self.user.id,
-                connectedTime: new Date(Date)
+                connectedTime: new Date()
               });
               // save support email details in journal
-              self.supportEmailDAO.put(email);
+              self.user.supportEmails.put(email);
               self.ctrl.add(foam.u2.dialog.Popup.create().tag({ class: 'foam.support.modal.NewEmailSupportConfirmationModal'}));
               X.closeDialog()
             } else {

--- a/src/foam/support/modal/NewEmailSupportModal.js
+++ b/src/foam/support/modal/NewEmailSupportModal.js
@@ -155,7 +155,9 @@ foam.CLASS({
               var email = self.SupportEmail.create({
                 email: self.email,
                 userId: self.user.id,
+                connectedTime: new Date(Date)
               });
+              // save support email details in journal
               self.supportEmailDAO.put(email);
               self.ctrl.add(foam.u2.dialog.Popup.create().tag({ class: 'foam.support.modal.NewEmailSupportConfirmationModal'}));
               X.closeDialog()

--- a/src/foam/support/modal/NewEmailSupportModal.js
+++ b/src/foam/support/modal/NewEmailSupportModal.js
@@ -122,18 +122,19 @@ foam.CLASS({
           title: 'New Email'
         }))
         .start().addClass('div2')
-        .start().addClass('label1') 
-            .add(this.titlelabel)
-        .end()
-        .start(this.EMAIL).addClass('input-wide').end()
-        .start().addClass('div')
-        .start(this.CLOSE_MODAL).addClass('Rectangle-7')
-        .end()
-          .startContext({ data : this })
-        .start(this.NEXT_BUTTON).addClass('Rectangle-8')
-        .end()
-          .endContext()
-        .end()
+          .start().addClass('label1')
+              .add(this.titlelabel)
+          .end()
+          .start(this.EMAIL).addClass('input-wide').end()
+          .start().addClass('div')
+            .start(this.CLOSE_MODAL).addClass('Rectangle-7')
+            .end()
+            .startContext({ data : this })
+              .start(this.NEXT_BUTTON).addClass('Rectangle-8')
+              .end()
+            .endContext()
+          .end()
+        .end();
       }
     ], 
 
@@ -172,9 +173,9 @@ foam.CLASS({
       },
       {
         name: 'closeModal',
-        label: 'Close',
-        code: function(X){
-          X.closeDialog()
+        label: 'Cancel',
+        code: function(X) {
+          X.closeDialog();
         }
       }
     ]

--- a/src/foam/support/modal/NewEmailSupportModal.js
+++ b/src/foam/support/modal/NewEmailSupportModal.js
@@ -105,12 +105,19 @@ foam.CLASS({
       {
         class: 'Long',
         name: 'id'
+      },
+      {
+        class: 'String',
+        name: 'emailRegex',
+        value: /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
       }
     ],
 
     messages:[
       { name:'title', message:'New Email' },
       { name:'titlelabel', message:'Input the email address you want to connect to the help desk.' },
+      { name:'emailInvalid', message: 'The email you have entered is invalid, try again.'},
+      { name:'emailNotExist', message: 'The email you have entered is existed.'}
     ],
 
     methods:[
@@ -143,12 +150,10 @@ foam.CLASS({
         name: 'nextButton',
         label: 'Next',
         code: function(X) {
-
           if(!this.email) return;
           var self = this;
-          const emailRegex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-          if (!emailRegex.test(this.email)) {
-            this.add(this.NotificationMessage.create({ message: 'The email you have entered is invalid, try again.', type: 'error' })); 
+          if (!this.emailRegex.test(this.email)) {
+            this.add(this.NotificationMessage.create({ message: this.emailInvalid, type: 'error' })); 
             return;
           }
 
@@ -165,7 +170,7 @@ foam.CLASS({
                 self.ctrl.add(foam.u2.dialog.Popup.create().tag({ class: 'foam.support.modal.NewEmailSupportConfirmationModal' }));
                 X.closeDialog();
               } else {
-                self.add(self.NotificationMessage.create({ message: 'The email you have entered is existed.', type: 'error' }));
+                self.add(self.NotificationMessage.create({ message: this.emailNotExist, type: 'error' }));
               }
             }
           );

--- a/src/foam/support/modal/NewEmailSupportModal.js
+++ b/src/foam/support/modal/NewEmailSupportModal.js
@@ -10,18 +10,18 @@ foam.CLASS({
   ],
 
   requires: [
-    'foam.u2.ModalHeader',
     'foam.support.model.SupportEmail',
-    'foam.u2.dialog.Popup',
     'foam.support.modal.NewEmailSupportConfirmationModal',
-    'foam.u2.dialog.NotificationMessage'
+    'foam.u2.ModalHeader',
+    'foam.u2.dialog.NotificationMessage',
+    'foam.u2.dialog.Popup'
   ],
 
   imports: [
     'closeDialog',
+    'ctrl',
     'supportEmailDAO',
     'user',
-    'ctrl'
   ],
 
   exports:[
@@ -116,8 +116,8 @@ foam.CLASS({
     messages:[
       { name:'title', message:'New Email' },
       { name:'titlelabel', message:'Input the email address you want to connect to the help desk.' },
-      { name:'emailInvalid', message: 'The email you have entered is invalid, try again.'},
-      { name:'emailNotExist', message: 'The email you have entered is existed.'}
+      { name:'emailInvalid', message: 'The email you have entered is invalid. Try again.'},
+      { name:'emailExists', message: 'The email you have entered already exists.'}
     ],
 
     methods:[
@@ -170,7 +170,7 @@ foam.CLASS({
                 self.ctrl.add(foam.u2.dialog.Popup.create().tag({ class: 'foam.support.modal.NewEmailSupportConfirmationModal' }));
                 X.closeDialog();
               } else {
-                self.add(self.NotificationMessage.create({ message: this.emailNotExist, type: 'error' }));
+                self.add(self.NotificationMessage.create({ message: this.emailExists, type: 'error' }));
               }
             }
           );

--- a/src/foam/support/model/SupportEmail.js
+++ b/src/foam/support/model/SupportEmail.js
@@ -23,7 +23,7 @@ foam.CLASS({
       }
     },
     {
-      class: 'Date',
+      class: 'DateTime',
       name: 'connectedTime'
     }
   ]

--- a/src/foam/support/model/SupportEmail.js
+++ b/src/foam/support/model/SupportEmail.js
@@ -12,6 +12,10 @@ foam.CLASS({
       name: 'email'
     },
     {
+      class: 'Password',
+      name: 'password'
+    },
+    {
       class: 'String',
       name: 'status',
       factory: function(){
@@ -21,14 +25,6 @@ foam.CLASS({
     {
       class: 'Date',
       name: 'connectedTime'
-    },
-    {
-      class: 'Long',
-      name: 'userId'
-    },
-    {
-      class: 'Password',
-      name: 'password'
     }
   ]
 });

--- a/src/foam/support/view/SupportEmailView.js
+++ b/src/foam/support/view/SupportEmailView.js
@@ -5,11 +5,12 @@ foam.CLASS({
 
   requires: [ 
     'foam.u2.ListCreateController',
-    'foam.u2.dialog.Popup'
+    'foam.u2.dialog.Popup',
+    'foam.u2.view.TableView'
   ],
 
   imports: [ 
-    'supportEmailDAO', 
+    'user',
     'createLabel',  
     'ctrl' 
   ],
@@ -119,7 +120,7 @@ foam.CLASS({
   methods: [
     function initE(){
       var self = this;
-      this.supportEmailDAO.limit(1).select().then(function(a){ 
+      this.user.supportEmails.limit(1).select().then(function(a){ 
         self.emptyDAO = a.array.length == 0;
       });
 
@@ -131,7 +132,7 @@ foam.CLASS({
           .start().addClass('align').end() 
           .start({
             class: 'foam.u2.ListCreateController',
-            dao: this.supportEmailDAO,
+            dao: this.user.supportEmails,
             summaryView: this.EmailSupportTableView.create(),
             showActions: false
           }).hide(this.emptyDAO$).end()
@@ -163,11 +164,20 @@ foam.CLASS({
       
       exports: [ 'as data' ],
       
-      imports: [ 'supportEmailDAO' ],
+      imports: [ 'user' ],
       
       properties: [
         'selection'
       ],
+
+      css:`
+        ^ .foam-u2-view-TableView-th-email{
+          width: 50%;
+        }
+        ^ .foam-u2-view-TableView-th-connectedTime{
+          width: 300%;
+        }
+      `,
       
   methods: [
       function initE() {
@@ -176,8 +186,8 @@ foam.CLASS({
             selection$: this.selection$,
             class: 'foam.u2.view.ScrollTableView',
             height: 20,
-            data: this.supportEmailDAO,
-            columns: ['id', 'email', 'status', 'connectedTime']
+            data: this.user.supportEmails,
+            columns: ['id', 'email', 'connectedTime', 'status']
           }).addClass(this.myClass('table')).end();
           }
         ] 

--- a/src/foam/support/view/SupportEmailView.js
+++ b/src/foam/support/view/SupportEmailView.js
@@ -26,7 +26,7 @@ foam.CLASS({
     ^ .foam-u2-UnstyledActionView-create {
       display: none;
     }
-    ^ .foam-u2-UnstyledActionView-newEmail{
+    ^ .foam-u2-UnstyledActionView-newEmail {
       width: 135px;
       height: 40px;
       border-radius: 2px;
@@ -46,7 +46,7 @@ foam.CLASS({
       margin: auto;
       margin-left: 
     }
-    ^ .btn-mid{
+    ^ .btn-mid {
       width: 100%;
       text-align: center;
       margin-top: 20px;
@@ -58,7 +58,7 @@ foam.CLASS({
       background-color: #ffffff;
       margin: auto;
     }
-    ^ .title{
+    ^ .title {
       width: 100%;
       height: 20px;
       opacity: 0.6;
@@ -75,22 +75,22 @@ foam.CLASS({
       padding-right: 10px;
       padding-top: 30px;
     }
-    ^ .title1{
+    ^ .title1 {
       padding: 2px;
       margin: 28px;
     }
-    ^ .align{
+    ^ .align {
       margin-left: 10px;
       margin-right: 10px;
       margin-bottom: 30px;
     }
-    ^ .input-container-half{
+    ^ .input-container-half {
       width: 960px;
       height: 35px;
       border-radius: 2px;
       background-color: #ffffff;
     }
-    ^ .No-support-email-con{
+    ^ .No-support-email-con {
       width: 183px;
       height: 16px;
       font-family: Roboto;
@@ -105,8 +105,11 @@ foam.CLASS({
       margin-left: 389px;
       margin-right: 388px
     }
-    ^ .foam-u2-view-TableView-th-connectedTime{
-      width: 140px;
+    ^ .foam-u2-view-TableView-th-connectedTime {
+      width: 50%;
+    }
+    ^ .foam-u2-view-TableView-th-email {
+      width: 30%;
     }
   `,
 
@@ -128,7 +131,9 @@ foam.CLASS({
       .addClass(this.myClass())
       .start().addClass('Rectangle-11-Copy')
         .start().addClass('title1')
-          .start().add('Support Email Management').addClass('title').end()
+          .start()
+            .add('Support Emails Management').addClass('title')
+          .end()
           .start().addClass('align').end() 
           .start({
             class: 'foam.u2.ListCreateController',
@@ -137,7 +142,9 @@ foam.CLASS({
             showActions: false
           }).hide(this.emptyDAO$).end()
           .start().addClass('input-container-half').show(this.emptyDAO$)
-            .start().add('No Email Support Connected').addClass('No-support-email-con').end()
+            .start()
+              .add('No support email connected').addClass('No-support-email-con')
+            .end()
           .end()
           .start().addClass('btn-mid')
             .start(this.NEW_EMAIL).end()
@@ -167,30 +174,32 @@ foam.CLASS({
       imports: [ 'user' ],
       
       properties: [
-        'selection'
-      ],
-
-      css:`
-        ^ .foam-u2-view-TableView-th-email{
-          width: 50%;
-        }
-        ^ .foam-u2-view-TableView-th-connectedTime{
-          width: 300%;
-        }
-      `,
-      
-  methods: [
-      function initE() {
-        this
-          .start({
-            selection$: this.selection$,
-            class: 'foam.u2.view.ScrollTableView',
-            height: 20,
-            data: this.user.supportEmails,
-            columns: ['id', 'email', 'connectedTime', 'status']
-          }).addClass(this.myClass('table')).end();
+        'selection',
+        {
+          name: 'data',
+          factory: function() {
+            return this.user.supportEmails;
           }
-        ] 
-      }
-    ]
-  });
+        }
+      ],
+      
+      methods: [
+        function initE() {
+          this
+            .start({
+              class: 'foam.u2.view.ScrollTableView',
+              selection$: this.selection$,
+              data: this.data,
+              columns: [
+                'email',
+                'connectedTime',
+                'status'
+              ]
+            })
+              .addClass(this.myClass('table'))
+            .end();
+        }
+      ] 
+    }
+  ]
+});

--- a/src/foam/support/view/SupportEmailView.js
+++ b/src/foam/support/view/SupportEmailView.js
@@ -3,16 +3,16 @@ foam.CLASS({
   name:'SupportEmailView',
   extends:'foam.u2.View',
 
-  requires: [ 
-    'foam.u2.ListCreateController',
+  requires: [
     'foam.u2.dialog.Popup',
+    'foam.u2.ListCreateController',
     'foam.u2.view.TableView'
   ],
 
-  imports: [ 
-    'user',
+  imports: [
     'createLabel',  
-    'ctrl' 
+    'ctrl',
+    'user'
   ],
 
   exports: [
@@ -120,6 +120,11 @@ foam.CLASS({
     }
   ],
 
+  messages:[
+    { name:'title', message: 'Support Emails Management' },
+    { name:'noSupportEmail', message: 'No support email connected' }
+  ],
+
   methods: [
     function initE(){
       var self = this;
@@ -132,7 +137,7 @@ foam.CLASS({
       .start().addClass('Rectangle-11-Copy')
         .start().addClass('title1')
           .start()
-            .add('Support Emails Management').addClass('title')
+            .add(this.title).addClass('title')
           .end()
           .start().addClass('align').end() 
           .start({
@@ -143,7 +148,7 @@ foam.CLASS({
           }).hide(this.emptyDAO$).end()
           .start().addClass('input-container-half').show(this.emptyDAO$)
             .start()
-              .add('No support email connected').addClass('No-support-email-con')
+              .add(this.noSupportEmail).addClass('No-support-email-con')
             .end()
           .end()
           .start().addClass('btn-mid')


### PR DESCRIPTION
#37, created User-SupportEmail relationship, and now the support email is associated with the specific user account.
#36, added the 'mlang' query to check if the email address existence.
#35, get back the connected-time on support email page.